### PR TITLE
for #3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ tests/*/*.sh
 php_json_post.o
 json_post-*.tgz
 tmp-php.ini
+*.dep

--- a/package.xml
+++ b/package.xml
@@ -36,10 +36,12 @@ This extension does not provide any constants, functions or classes.
  <license uri="http://copyfree.org/content/standard/licenses/2bsd/license.txt">BSD-2-Clause</license>
  <notes><![CDATA[
 * Fix gh-issue #3:
-    * Add json_post.error_response INI entry, specifying whether and which
+    * Add json_post.onerror.response INI entry, specifying whether and which
       response code to send when `json_decode` fails.
-    * Add json_post.error_exit INI entry, specifying whether to exit PHP
+    * Add json_post.onerror.exit INI entry, specifying whether to exit PHP
       without running the script when `json_decode` fails.
+    * Add json_post.onerror.warning INI entry, specifying whether to raise
+			a WARNING when `json_decode` fails.
 ]]></notes>
  <contents>
   <dir name="/">

--- a/package.xml
+++ b/package.xml
@@ -24,9 +24,9 @@ This extension does not provide any constants, functions or classes.
   <email>mike@php.net</email>
   <active>yes</active>
  </lead>
- <date>2020-05-25</date>
+ <date>2021-09-16</date>
  <version>
-  <release>1.0.2</release>
+  <release>1.1.0</release>
   <api>1.0.0</api>
  </version>
  <stability>
@@ -35,8 +35,12 @@ This extension does not provide any constants, functions or classes.
  </stability>
  <license uri="http://copyfree.org/content/standard/licenses/2bsd/license.txt">BSD-2-Clause</license>
  <notes><![CDATA[
- * Fix gh-issue #1: segfault on 7.4 with empty array (Mark Rigby-Jones)
-]]></notes>
+* Fix gh-issue #3:
+    * Add json_post.error_response INI entry, specifying whether and which
+      response code to send when `json_decode` fails.
+    * Add json_post.error_exit INI entry, specifying whether to exit PHP
+      without running the script when `json_decode` fails.
+]></notes>
  <contents>
   <dir name="/">
    <file role="doc" name="AUTHORS"/>

--- a/package.xml
+++ b/package.xml
@@ -40,7 +40,7 @@ This extension does not provide any constants, functions or classes.
       response code to send when `json_decode` fails.
     * Add json_post.error_exit INI entry, specifying whether to exit PHP
       without running the script when `json_decode` fails.
-]></notes>
+]]></notes>
  <contents>
   <dir name="/">
    <file role="doc" name="AUTHORS"/>

--- a/php_json_post.c
+++ b/php_json_post.c
@@ -25,7 +25,7 @@
 ZEND_DECLARE_MODULE_GLOBALS(json_post);
 
 PHP_INI_BEGIN()
-    STD_PHP_INI_ENTRY("json_post.flags", "1", PHP_INI_PERDIR, OnUpdateLong, flags, zend_json_post_globals, json_post_globals)
+	STD_PHP_INI_ENTRY("json_post.flags", "1", PHP_INI_PERDIR, OnUpdateLong, flags, zend_json_post_globals, json_post_globals)
 	STD_PHP_INI_ENTRY("json_post.error_response", "0", PHP_INI_PERDIR, OnUpdateLong, error_response, zend_json_post_globals, json_post_globals)
 	STD_PHP_INI_ENTRY("json_post.error_exit", "0", PHP_INI_PERDIR, OnUpdateBool, error_exit, zend_json_post_globals, json_post_globals)
 PHP_INI_END()

--- a/php_json_post.c
+++ b/php_json_post.c
@@ -161,6 +161,8 @@ static SAPI_POST_HANDLER_FUNC(php_json_post_handler)
 			sapi_send_headers(TSRMLS_C);
 			zend_bailout();
 		}
+		/* ext/json in PHP-7 fails to reset error_code in RINIT */
+		JSON_G(error_code) = 0;
 	}
 }
 

--- a/php_json_post.c
+++ b/php_json_post.c
@@ -59,7 +59,7 @@ PHP_MINFO_FUNCTION(json_post)
 #if PHP_VERSION_ID < 70000
 #	undef JSON_G
 #	ifdef ZTS
-#		define JSON_G(v) TSRMG(JSON_POST_G(json_module)->globals_id_ptr, zend_json_globals *, v)
+#		define JSON_G(v) TSRMG(*JSON_POST_G(json_module)->globals_id_ptr, zend_json_globals *, v)
 #	else
 #		define JSON_G(v) ((zend_json_globals *) JSON_POST_G(json_module)->globals_ptr)->v
 #	endif

--- a/php_json_post.h
+++ b/php_json_post.h
@@ -16,7 +16,7 @@
 extern zend_module_entry json_post_module_entry;
 #define phpext_json_post_ptr &json_post_module_entry
 
-#define PHP_JSON_POST_VERSION "1.0.2"
+#define PHP_JSON_POST_VERSION "1.1.0"
 
 #ifdef PHP_WIN32
 #	define PHP_JSON_POST_API __declspec(dllexport)
@@ -32,6 +32,8 @@ extern zend_module_entry json_post_module_entry;
 
 ZEND_BEGIN_MODULE_GLOBALS(json_post)
 	long flags;
+	int error_response;
+	zend_bool error_exit;
 ZEND_END_MODULE_GLOBALS(json_post)
 
 ZEND_EXTERN_MODULE_GLOBALS(json_post);

--- a/php_json_post.h
+++ b/php_json_post.h
@@ -41,6 +41,9 @@ ZEND_BEGIN_MODULE_GLOBALS(json_post)
 		zend_bool warning;
 		zend_bool exit;
 	} onerror;
+#if PHP_VERSION_ID < 70000
+	zend_function *json_last_error;
+#endif
 ZEND_END_MODULE_GLOBALS(json_post)
 
 ZEND_EXTERN_MODULE_GLOBALS(json_post);

--- a/php_json_post.h
+++ b/php_json_post.h
@@ -42,7 +42,7 @@ ZEND_BEGIN_MODULE_GLOBALS(json_post)
 		zend_bool exit;
 	} onerror;
 #if PHP_VERSION_ID < 70000
-	zend_function *json_last_error;
+	zend_module_entry *json_module;
 #endif
 ZEND_END_MODULE_GLOBALS(json_post)
 

--- a/php_json_post.h
+++ b/php_json_post.h
@@ -30,10 +30,17 @@ extern zend_module_entry json_post_module_entry;
 #	include "TSRM.h"
 #endif
 
+#if PHP_VERSION_ID < 70000
+typedef long zend_long;
+#endif
+
 ZEND_BEGIN_MODULE_GLOBALS(json_post)
-	long flags;
-	int error_response;
-	zend_bool error_exit;
+	zend_long flags;
+	struct {
+		zend_long response;
+		zend_bool warning;
+		zend_bool exit;
+	} onerror;
 ZEND_END_MODULE_GLOBALS(json_post)
 
 ZEND_EXTERN_MODULE_GLOBALS(json_post);

--- a/tests/error.inc
+++ b/tests/error.inc
@@ -1,0 +1,11 @@
+<?php
+if ($_POST)
+	var_dump(compact("_POST"));
+if (($json_last_error = json_last_error()))
+	var_dump(compact("json_last_error"));
+if (($JSON_POST_ERROR = JSON_POST_ERROR) !== 3)
+	var_dump(compact("JSON_POST_ERROR"));
+if (($http_response_code = http_response_code()) != ini_get("json_post.onerror.response") && ini_get("json_post.onerror.response"))
+	var_dump(compact("http_response_code"));
+?>
+DONE

--- a/tests/error.inc
+++ b/tests/error.inc
@@ -1,9 +1,9 @@
 <?php
 if ($_POST)
 	var_dump(compact("_POST"));
-if (($json_last_error = json_last_error()))
+if (PHP_VERSION_ID >= 70000 && ($json_last_error = json_last_error()))
 	var_dump(compact("json_last_error"));
-if (($JSON_POST_ERROR = JSON_POST_ERROR) !== 3)
+if (($JSON_POST_ERROR = JSON_POST_ERROR) !== (PHP_VERSION_ID < 70000 ? 4 : 3))
 	var_dump(compact("JSON_POST_ERROR"));
 if (($http_response_code = http_response_code()) != ini_get("json_post.onerror.response") && ini_get("json_post.onerror.response"))
 	var_dump(compact("http_response_code"));

--- a/tests/error001.phpt
+++ b/tests/error001.phpt
@@ -1,7 +1,5 @@
 --TEST--
 json_post with malformed JSON [default] (https://github.com/m6w6/ext-json_post/issues/3)
---EXTENSIONS--
-json_post
 --POST_RAW--
 Content-Type: application/json
 

--- a/tests/error001.phpt
+++ b/tests/error001.phpt
@@ -1,28 +1,13 @@
 --TEST--
-json_post with malformed JSON (https://github.com/m6w6/ext-json_post/issues/3)
---SKIPIF--
-<?php
-extension_loaded("json_post") or die("skip need json_post support\n");
-?>
---INI--
-json_post.error_response = 400
+json_post with malformed JSON [default] (https://github.com/m6w6/ext-json_post/issues/3)
+--EXTENSIONS--
+json_post
 --POST_RAW--
 Content-Type: application/json
 
-{
-	"greeting": "Hello World
-}
---FILE--
-<?php
-var_dump($_POST);
-var_dump(json_last_error());
-?>
-Done
+{"a
+--FILE_EXTERNAL--
+error.inc
 --EXPECTHEADERS--
-Status: 400 Bad Request
-X-JSON-Error-Code: 3
---EXPECTF--
-array(0) {
-}
-int(0)
-Done
+--EXPECT--
+DONE

--- a/tests/error001.phpt
+++ b/tests/error001.phpt
@@ -1,0 +1,28 @@
+--TEST--
+json_post with malformed JSON (https://github.com/m6w6/ext-json_post/issues/3)
+--SKIPIF--
+<?php
+extension_loaded("json_post") or die("skip need json_post support\n");
+?>
+--INI--
+json_post.error_response = 400
+--POST_RAW--
+Content-Type: application/json
+
+{
+	"greeting": "Hello World
+}
+--FILE--
+<?php
+var_dump($_POST);
+var_dump(json_last_error());
+?>
+Done
+--EXPECTHEADERS--
+Status: 400 Bad Request
+X-JSON-Error-Code: 3
+--EXPECTF--
+array(0) {
+}
+int(0)
+Done

--- a/tests/error002.phpt
+++ b/tests/error002.phpt
@@ -3,7 +3,7 @@ json_post with malformed JSON (https://github.com/m6w6/ext-json_post/issues/3)
 --SKIPIF--
 <?php
 extension_loaded("json_post") or die("skip need json_post support\n");
-if (PHP_VERSION_ID < 70000) doe("skip need PHP-7.0+\n");
+if (PHP_VERSION_ID < 70000) die("skip need PHP-7.0+\n");
 ?>
 --INI--
 json_post.error_response = 400

--- a/tests/error002.phpt
+++ b/tests/error002.phpt
@@ -1,0 +1,30 @@
+--TEST--
+json_post with malformed JSON (https://github.com/m6w6/ext-json_post/issues/3)
+--SKIPIF--
+<?php
+extension_loaded("json_post") or die("skip need json_post support\n");
+if (PHP_VERSION_ID < 70000) doe("skip need PHP-7.0+\n");
+?>
+--INI--
+json_post.error_response = 400
+json_post.flags = 4194305
+--POST_RAW--
+Content-Type: application/json
+
+{
+	"greeting": "Hello World
+}
+--FILE--
+<?php
+var_dump($_POST);
+var_dump(http_response_code());
+?>
+Done
+--EXPECTHEADERS--
+Status: 400 Bad Request
+X-JSON-Error-Code: 3
+--EXPECTF--
+array(0) {
+}
+int(400)
+Done

--- a/tests/error002.phpt
+++ b/tests/error002.phpt
@@ -1,30 +1,16 @@
 --TEST--
-json_post with malformed JSON (https://github.com/m6w6/ext-json_post/issues/3)
---SKIPIF--
-<?php
-extension_loaded("json_post") or die("skip need json_post support\n");
-if (PHP_VERSION_ID < 70000) die("skip need PHP-7.0+\n");
-?>
+json_post with malformed JSON [response] (https://github.com/m6w6/ext-json_post/issues/3)
+--EXTENSIONS--
+json_post
 --INI--
-json_post.error_response = 400
-json_post.flags = 4194305
+json_post.onerror.response = 400
 --POST_RAW--
 Content-Type: application/json
 
-{
-	"greeting": "Hello World
-}
---FILE--
-<?php
-var_dump($_POST);
-var_dump(http_response_code());
-?>
-Done
+{"a
+--FILE_EXTERNAL--
+error.inc
 --EXPECTHEADERS--
 Status: 400 Bad Request
-X-JSON-Error-Code: 3
---EXPECTF--
-array(0) {
-}
-int(400)
-Done
+--EXPECT--
+DONE

--- a/tests/error002.phpt
+++ b/tests/error002.phpt
@@ -1,7 +1,5 @@
 --TEST--
 json_post with malformed JSON [response] (https://github.com/m6w6/ext-json_post/issues/3)
---EXTENSIONS--
-json_post
 --INI--
 json_post.onerror.response = 400
 --POST_RAW--

--- a/tests/error003.phpt
+++ b/tests/error003.phpt
@@ -1,7 +1,5 @@
 --TEST--
 json_post with malformed JSON [warning] (https://github.com/m6w6/ext-json_post/issues/3)
---EXTENSIONS--
-json_post
 --INI--
 json_post.onerror.warning = on
 --POST_RAW--
@@ -12,5 +10,5 @@ Content-Type: application/json
 error.inc
 --EXPECTHEADERS--
 --EXPECTF--
-Warning: json_post: json_decode failed with error code: 3 in %s on line %s
+Warning: json_post: json_decode failed with error code: %d in %s on line %s
 DONE

--- a/tests/error003.phpt
+++ b/tests/error003.phpt
@@ -1,0 +1,25 @@
+--TEST--
+json_post with malformed JSON (https://github.com/m6w6/ext-json_post/issues/3)
+--SKIPIF--
+<?php
+extension_loaded("json_post") or die("skip need json_post support\n");
+?>
+--INI--
+json_post.error_response = 444
+json_post.error_exit = true
+--POST_RAW--
+Content-Type: application/json
+
+{
+	"greeting": "Hello World
+}
+--FILE--
+<?php
+var_dump($_POST);
+var_dump(http_response_code());
+?>
+Done
+--EXPECTHEADERS--
+Status: 444
+X-JSON-Error-Code: 3
+--EXPECT--

--- a/tests/error003.phpt
+++ b/tests/error003.phpt
@@ -1,25 +1,16 @@
 --TEST--
-json_post with malformed JSON (https://github.com/m6w6/ext-json_post/issues/3)
---SKIPIF--
-<?php
-extension_loaded("json_post") or die("skip need json_post support\n");
-?>
+json_post with malformed JSON [warning] (https://github.com/m6w6/ext-json_post/issues/3)
+--EXTENSIONS--
+json_post
 --INI--
-json_post.error_response = 444
-json_post.error_exit = true
+json_post.onerror.warning = on
 --POST_RAW--
 Content-Type: application/json
 
-{
-	"greeting": "Hello World
-}
---FILE--
-<?php
-var_dump($_POST);
-var_dump(http_response_code());
-?>
-Done
+{"a
+--FILE_EXTERNAL--
+error.inc
 --EXPECTHEADERS--
-Status: 444
-X-JSON-Error-Code: 3
---EXPECT--
+--EXPECTF--
+Warning: json_post: json_decode failed with error code: 3 in %s on line %s
+DONE

--- a/tests/error004.phpt
+++ b/tests/error004.phpt
@@ -1,7 +1,5 @@
 --TEST--
 json_post with malformed JSON [exit] (https://github.com/m6w6/ext-json_post/issues/3)
---EXTENSIONS--
-json_post
 --INI--
 json_post.onerror.exit = true
 --POST_RAW--

--- a/tests/error004.phpt
+++ b/tests/error004.phpt
@@ -1,0 +1,22 @@
+--TEST--
+json_post with malformed JSON (https://github.com/m6w6/ext-json_post/issues/3)
+--SKIPIF--
+<?php
+extension_loaded("json_post") or die("skip need json_post support\n");
+?>
+--INI--
+json_post.error_exit = true
+--POST_RAW--
+Content-Type: application/json
+
+{
+	"greeting": "Hello World
+}
+--FILE--
+<?php
+var_dump($_POST);
+var_dump(http_response_code());
+?>
+Done
+--EXPECTHEADERS--
+--EXPECT--

--- a/tests/error005.phpt
+++ b/tests/error005.phpt
@@ -1,7 +1,5 @@
 --TEST--
 json_post with malformed JSON [response override] (https://github.com/m6w6/ext-json_post/issues/3)
---EXTENSIONS--
-json_post
 --INI--
 json_post.onerror.response = 444
 --POST_RAW--

--- a/tests/error005.phpt
+++ b/tests/error005.phpt
@@ -3,7 +3,7 @@ json_post with malformed JSON (https://github.com/m6w6/ext-json_post/issues/3)
 --SKIPIF--
 <?php
 extension_loaded("json_post") or die("skip need json_post support\n");
-if (PHP_VERSION_ID < 70000) doe("skip need PHP-7.0+\n");
+if (PHP_VERSION_ID < 70000) die("skip need PHP-7.0+\n");
 ?>
 --INI--
 json_post.error_response = 444

--- a/tests/error005.phpt
+++ b/tests/error005.phpt
@@ -1,0 +1,31 @@
+--TEST--
+json_post with malformed JSON (https://github.com/m6w6/ext-json_post/issues/3)
+--SKIPIF--
+<?php
+extension_loaded("json_post") or die("skip need json_post support\n");
+if (PHP_VERSION_ID < 70000) doe("skip need PHP-7.0+\n");
+?>
+--INI--
+json_post.error_response = 444
+json_post.flags = 1
+--POST_RAW--
+Content-Type: application/json
+
+{
+	"greeting": "Hello World
+}
+--FILE--
+<?php
+http_response_code(400);
+var_dump($_POST);
+var_dump(http_response_code());
+?>
+Done
+--EXPECTHEADERS--
+Status: 400 Bad Request
+X-JSON-Error-Code: 3
+--EXPECTF--
+array(0) {
+}
+int(400)
+Done

--- a/tests/error005.phpt
+++ b/tests/error005.phpt
@@ -1,31 +1,24 @@
 --TEST--
-json_post with malformed JSON (https://github.com/m6w6/ext-json_post/issues/3)
---SKIPIF--
-<?php
-extension_loaded("json_post") or die("skip need json_post support\n");
-if (PHP_VERSION_ID < 70000) die("skip need PHP-7.0+\n");
-?>
+json_post with malformed JSON [response override] (https://github.com/m6w6/ext-json_post/issues/3)
+--EXTENSIONS--
+json_post
 --INI--
-json_post.error_response = 444
-json_post.flags = 1
+json_post.onerror.response = 444
 --POST_RAW--
 Content-Type: application/json
 
-{
-	"greeting": "Hello World
-}
+{"a
 --FILE--
 <?php
-http_response_code(400);
-var_dump($_POST);
-var_dump(http_response_code());
+if (JSON_POST_ERROR)
+	http_response_code(400);
+include "./error.inc";
 ?>
-Done
 --EXPECTHEADERS--
 Status: 400 Bad Request
-X-JSON-Error-Code: 3
---EXPECTF--
-array(0) {
+--EXPECT--
+array(1) {
+  ["http_response_code"]=>
+  int(400)
 }
-int(400)
-Done
+DONE

--- a/tests/error006.phpt
+++ b/tests/error006.phpt
@@ -1,7 +1,5 @@
 --TEST--
 json_post with malformed JSON [json_throw] (https://github.com/m6w6/ext-json_post/issues/3)
---EXTENSIONS--
-json_post
 --INI--
 json_post.flags = 4194305
 --POST_RAW--

--- a/tests/error006.phpt
+++ b/tests/error006.phpt
@@ -1,9 +1,9 @@
 --TEST--
-json_post with malformed JSON [exit] (https://github.com/m6w6/ext-json_post/issues/3)
+json_post with malformed JSON [json_throw] (https://github.com/m6w6/ext-json_post/issues/3)
 --EXTENSIONS--
 json_post
 --INI--
-json_post.onerror.exit = true
+json_post.flags = 4194305
 --POST_RAW--
 Content-Type: application/json
 
@@ -12,3 +12,4 @@ Content-Type: application/json
 error.inc
 --EXPECTHEADERS--
 --EXPECT--
+DONE


### PR DESCRIPTION
Fix issue #3:

* Add json_post.error_response INI entry, specifying whether and which
  response code to send when `json_decode` fails.
* Add json_post.error_exit INI entry, specifying whether to exit PHP
  without running the script when `json_decode` fails.